### PR TITLE
disable wrapping of WebContents by NavigationController

### DIFF
--- a/lib/browser/api/web-contents.js
+++ b/lib/browser/api/web-contents.js
@@ -81,18 +81,27 @@ let wrapWebContents = function(webContents) {
   };
 
   // The navigation controller.
-  controller = new NavigationController(webContents);
-  ref1 = NavigationController.prototype;
-  for (name in ref1) {
-    method = ref1[name];
-    if (method instanceof Function) {
-      (function(name, method) {
-        return webContents[name] = function() {
-          return method.apply(controller, arguments);
-        };
-      })(name, method);
-    }
-  }
+  //
+  // mozbrowserlocationchange doesn't provide the inPage and replaceEntry
+  // metadata that would be required for NavigationController to "compeletely do
+  // history control on user land" (as navigation-controller.js describes it).
+  //
+  // So we disable the wrapping of WebContents by NavigationController
+  // and then implement methods that are unique to NavigationController
+  // over in atom_browser_web_contents.js.
+  //
+  // controller = new NavigationController(webContents);
+  // ref1 = NavigationController.prototype;
+  // for (name in ref1) {
+  //   method = ref1[name];
+  //   if (method instanceof Function) {
+  //     (function(name, method) {
+  //       return webContents[name] = function() {
+  //         return method.apply(controller, arguments);
+  //       };
+  //     })(name, method);
+  //   }
+  // }
 
   // Mapping webFrame methods.
   for (let method of webFrameMethods) {


### PR DESCRIPTION
mozbrowserlocationchange doesn't provide the inPage and replaceEntry
metadata that would be required for NavigationController to "compeletely do
history control on user land" (as navigation-controller.js describes it).

So we disable the wrapping of WebContents by NavigationController
and then implement methods that are unique to NavigationController
over in atom_browser_web_contents.js.
